### PR TITLE
Br/fix for find_by_coordinates

### DIFF
--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -3,7 +3,7 @@ class King < Piece
   def valid_move?(new_x, new_y)
   	guard_move_is_on_board?(new_x, new_y)
   	return false unless one_space?(new_x, new_y)
-  	piece = Piece.find_by_coordinates(new_x, new_y)
+  	piece = game.pieces.find_by_coordinates(new_x, new_y)
   	return false unless piece == nil || piece.color != self.color
   	return true
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -36,6 +36,7 @@ class Piece < ActiveRecord::Base
 
   def self.find_by_coordinates(column, row)
     # Finds a piece by the given coordinates.
+    # When you call this method you should narrow the results to a specific game.
     where(y_coordinate: row, x_coordinate: column).first
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -34,7 +34,7 @@ class Piece < ActiveRecord::Base
 
   end
 
-  def self.find_by_coordinates(row, column)
+  def self.find_by_coordinates(column, row)
     # Finds a piece by the given coordinates.
     where(y_coordinate: row, x_coordinate: column).first
   end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -4,7 +4,7 @@
       <% (0..7).each do |column| %>
         <% square_color = (row + column).odd? ? 'black' : 'white' %>
         <td class="<%= square_color %>-space">
-          <% if piece = @game.pieces.find_by_coordinates(row, column) %>
+          <% if piece = @game.pieces.find_by_coordinates(column, row) %>
             <%= link_to piece_path(piece) do %>
               <span class="<%= piece.glyph %>" ></span>
             <% end %>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -7,7 +7,7 @@
           <td class="<%= square_color %>-space" id="<%= is_chosen_square %>">
             <%= link_to piece_path(@chosen_piece, y_coordinate: row,
               x_coordinate: column), method: :put, class: 'square' do %>
-            <% if piece = @game.pieces.find_by_coordinates(row, column) %>
+            <% if piece = @game.pieces.find_by_coordinates(column, row) %>
               <span class="<%= piece.glyph %>" ></span>
             <% end %>
           <% end %>


### PR DESCRIPTION
I had originally written the find_by_coordinates method for the view to use for drawing the pieces on the board. Because the view draws the row first, then the column, it made sense to me to order the arguments as row, then column. This is inconsistent with all the other methods that are called with coordinates as arguments. So I switched the argument order on the method definition and the calls in the views.

I also narrowed the scope of the find_by_coordinates call in the King model by calling it on game.pieces rather than Piece. With out this, the method searches all games for a piece on that square, thus making pieces that should be able to move unable to do so.
