### PR TITLE
Br/capture

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -15,8 +15,7 @@ class PiecesController < ApplicationController
     # pieces.  Remove this comment when you the other pieces are finished.
     x_move = params[:x_coordinate].to_i
     y_move = params[:y_coordinate].to_i
-    return redirect_to :back unless @piece.valid_move?(x_move, y_move)
-    @piece.update(piece_params)
+    return redirect_to :back unless @piece.move(x_move, y_move)
     redirect_to game_path(@piece.game)
   end
 

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -3,8 +3,7 @@ class Bishop < Piece
   def valid_move?(x_new, y_new)
     return false unless move_is_diagonal?(x_new, y_new)
     return false if is_obstructed?(x_new, y_new)
-    return false unless actual_move?(x_new, y_new)
-    return false if move_attacking_own_piece?(x_new, y_new, color)
+    return false unless super
     true
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -30,6 +30,18 @@ class Piece < ActiveRecord::Base
     return "glyphicon glyphicon-#{glyph_type} glyph-#{glyph_color} piece"
   end
 
+  def move(x_new, y_new)
+    if valid_move?(x_new, y_new)
+      captured_piece = game.pieces.find_by_coordinates(x_new, y_new)
+      if captured_piece
+        captured_piece.destroy
+      end
+      update_attributes(x_coordinate: x_new, y_coordinate: y_new)
+      return true if save
+    end
+    false
+  end
+
   def valid_move?(x_new, y_new)
 
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -43,7 +43,12 @@ class Piece < ActiveRecord::Base
   end
 
   def valid_move?(x_new, y_new)
-
+    # I pulled out the portions of the valid move method that all piece types
+    # should be calling, and placed them here. Check the bishop model to see
+    # how to call it.
+    return false unless actual_move?(x_new, y_new)
+    return false if move_attacking_own_piece?(x_new, y_new, color)
+    true
   end
 
   def self.find_by_coordinates(column, row)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -33,9 +33,8 @@ class Piece < ActiveRecord::Base
   def move(x_new, y_new)
     if valid_move?(x_new, y_new)
       captured_piece = game.pieces.find_by_coordinates(x_new, y_new)
-      if captured_piece
-        captured_piece.destroy
-      end
+      # This next line checks that a captured piece exists and destroys it.
+      captured_piece && captured_piece.destroy
       update_attributes(x_coordinate: x_new, y_coordinate: y_new)
       return true if save
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'returns false when an unobstructed diagonal move is made' do
-      expect(@queen.is_obstructed?(7, 7)).to eq false 
+      expect(@queen.is_obstructed?(7, 7)).to eq false
     end
 
     it 'returns true when an obstructed horizontal move is made' do
@@ -47,6 +47,41 @@ RSpec.describe Piece, type: :model do
     it 'returns false if an unobstructed move attempts to capture a piece' do
       create(:pawn, x_coordinate: 6, y_coordinate: 6, game_id: @game.id)
       expect(@queen.is_obstructed?(6, 6)).to eq false
+    end
+  end
+
+  describe "move method" do
+    before(:each) do
+      @game = create(:game)
+      @game.pieces.destroy_all
+      @bishop = create(:bishop, game_id: @game.id)
+    end
+    it 'moves the piece to the correct place when move is valid' do
+      @bishop.move(5, 5)
+      @bishop.reload
+      expect(@bishop.x_coordinate).to eq 5
+      expect(@bishop.y_coordinate).to eq 5
+    end
+    it 'does not move piece on an invalid move' do
+      @bishop.move(4, 5)
+      @bishop.reload
+      expect(@bishop.x_coordinate).to eq 2
+      expect(@bishop.y_coordinate).to eq 2
+    end
+  end
+
+  describe 'capturing another piece' do
+    before(:each) do
+      @game = create(:game)
+      @game.pieces.destroy_all
+      @bishop = create(:bishop, game_id: @game.id)
+      @pawn = create(:pawn, color: 'Black', game_id: @game.id, x_coordinate: 5, y_coordinate: 5)
+    end
+    it 'removes the captured piece' do
+      pawn_id = @pawn.id
+
+      @bishop.move(5, 5)
+      expect(Piece.find_by_id(pawn_id)).to be_nil
     end
   end
 end


### PR DESCRIPTION
I created a move method for the Piece model. The method calls valid_move then destroys any pieces that are in the space to be moved to. (Therefore it is imperative that the valid_move methods are correct.)
Then the move method moves the piece to that square.

Also, I pulled some of the code that all the piece type models should be calling for the valid move method into the Piece model. This can then be called from the piece specific valid_move method. 

I did this for the bishop, and I tried with the others, but goat failing tests when I did it for the King and Rook models. I will look into why that happened.
