### PR TITLE
Added a moved column to piece model. 

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -35,7 +35,7 @@ class Piece < ActiveRecord::Base
       captured_piece = game.pieces.find_by_coordinates(x_new, y_new)
       # This next line checks that a captured piece exists and destroys it.
       captured_piece && captured_piece.destroy
-      update_attributes(x_coordinate: x_new, y_coordinate: y_new)
+      update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
       return true if save
     end
     false

--- a/db/migrate/20160305015502_add_moved_to_pieces.rb
+++ b/db/migrate/20160305015502_add_moved_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddMovedToPieces < ActiveRecord::Migration
+  def change
+    add_column :pieces, :moved, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217045755) do
+ActiveRecord::Schema.define(version: 20160305015502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20160217045755) do
     t.integer  "player_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "moved",        default: false
   end
 
   create_table "players", force: true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,6 +22,7 @@ FactoryGirl.define do
     color 'white'
     x_coordinate 2
     y_coordinate 2
+    moved false
     factory :queen, class: Queen do
       type 'Queen'
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe Piece, type: :model do
       expect(@bishop.x_coordinate).to eq 2
       expect(@bishop.y_coordinate).to eq 2
     end
+
+    it 'changes the moved attribute to true' do
+      @bishop.move(5, 5)
+      @bishop.reload
+      expect(@bishop.moved).to be true
+    end
   end
 
   describe 'capturing another piece' do


### PR DESCRIPTION
Moving a piece changes moved from false to true.

I set the moved default value to false, so nothing needs to be added to the initializer, and when the database is migrated all currently existing pieces will have their moved values set to false.
