### PR TITLE
Pawn bug fix refactor

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,7 +1,7 @@
 # Class for Knight Piece
 class Knight < Piece
   def valid_move?(x_new, y_new)
-    return false if guard_move_is_on_board?(x_new, y_new) == false
+    guard_move_is_on_board?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     move_x = (x_new - self.x_coordinate).abs
     move_y = (y_new - self.y_coordinate).abs

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -2,12 +2,13 @@
 class Pawn < Piece
   def valid_move?(x_new, y_new)
     return false if guard_move_is_on_board?(x_new, y_new)
+    return false if is_obstructed?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     return false unless forward_move?(y_new)
     move_y = move_y(y_new)
     move_x = move_x(x_new)
     return false unless (first_move? && move_y.abs <= 2) || move_y.abs <= 1
-    if obstructed?(x_new, y_new) || move_x != 0
+    if space_occupied?(x_new, y_new) || move_x != 0
       return false unless attack?(x_new, y_new)
     end
     true
@@ -35,7 +36,7 @@ class Pawn < Piece
     false
   end
 
-  def obstructed?(x_new, y_new)
+  def space_occupied?(x_new, y_new)
     game.pieces.where(x_coordinate: x_new, y_coordinate: y_new).first
   end
 
@@ -43,7 +44,7 @@ class Pawn < Piece
     move_x = move_x(x_new)
     move_y = move_y(y_new).abs
     return false unless move_x == 1 && move_y == 1
-    return false unless obstructed?(x_new, y_new)
+    return false unless space_occupied?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     true
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,21 +1,23 @@
 # Class for Pawn Piece
 class Pawn < Piece
   def valid_move?(x_new, y_new)
-    move_y = move_y(y_new)
-    move_x = move_x(x_new)
     return false if guard_move_is_on_board?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
-    return false if backwards_move?(y_new)
+    return false unless forward_move?(y_new)
+    move_y = move_y(y_new)
+    move_x = move_x(x_new)
     return false unless (first_move? && move_y.abs <= 2) || move_y.abs <= 1
-    return false if move_x != 0 && !diagonal_attack_move?(x_new, y_new)
+    if obstructed?(x_new, y_new) || move_x != 0
+      return false unless attack?(x_new, y_new)
+    end
     true
   end
 
-  def backwards_move?(y_new)
+  def forward_move?(y_new)
     move_y = move_y(y_new)
-    return true if color == 'White' && move_y <= 0
-    return true if color == 'Black' && move_y >= 0
-    false
+    return false if color == 'White' && move_y <= 0
+    return false if color == 'Black' && move_y >= 0
+    true
   end
 
   def move_y(y_new)
@@ -33,8 +35,16 @@ class Pawn < Piece
     false
   end
 
-  def diagonal_attack_move?(x_new, y_new)
+  def obstructed?(x_new, y_new)
+    game.pieces.where(x_coordinate: x_new, y_coordinate: y_new).first
+  end
+
+  def attack?(x_new, y_new)
     move_x = move_x(x_new)
-    false unless move_x == 1 && is_obstructed?(x_new, y_new)
+    move_y = move_y(y_new).abs
+    return false unless move_x == 1 && move_y == 1
+    return false unless obstructed?(x_new, y_new)
+    return false if move_attacking_own_piece?(x_new, y_new, color)
+    true
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -30,9 +30,7 @@ class Pawn < Piece
   end
 
   def first_move?
-    return true if color == 'White' && y_coordinate == 1
-    return true if color == 'Black' && y_coordinate == 6
-    false
+    !moved
   end
 
   def space_occupied?(x_new, y_new)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,7 +1,7 @@
 # Class for Pawn Piece
 class Pawn < Piece
   def valid_move?(x_new, y_new)
-    return false if guard_move_is_on_board?(x_new, y_new)
+    return false if guard_move_is_on_board?(x_new, y_new) == false
     return false if is_obstructed?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     return false unless forward_move?(y_new)
@@ -37,7 +37,7 @@ class Pawn < Piece
   end
 
   def space_occupied?(x_new, y_new)
-    game.pieces.where(x_coordinate: x_new, y_coordinate: y_new).first
+    game.pieces.find_by_coordinates(x_new, y_new)
   end
 
   def attack?(x_new, y_new)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,7 +1,6 @@
 # Class for Pawn Piece
 class Pawn < Piece
   def valid_move?(x_new, y_new)
-    return false if guard_move_is_on_board?(x_new, y_new) == false
     return false if is_obstructed?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     return false unless forward_move?(y_new)

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe Pawn, type: :model do
         expect(@pawn.valid_move?(0, 2)).to eq(false)
       end
 
+      it 'returns false when attempting a 2 space move over another piece' do
+        create(:knight, x_coordinate: 0, y_coordinate: 2, game_id: @game.id, color: 'Black')
+        expect(@pawn.valid_move?(0, 3)).to eq(false)
+      end
+
       it 'returns false for a move 1 right, 0 forward' do
         expect(@pawn.valid_move?(1, 1)).to eq(false)
       end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Pawn, type: :model do
       end
 
       it 'returns false for a move forward 2 spaces when not the first move' do
-        @pawn.y_coordinate = 2
+        @pawn.move(0, 2)
         expect(@pawn.valid_move?(0, 4)).to eq(false)
       end
 

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Pawn, type: :model do
         expect(@pawn.valid_move?(0, 2)).to eq(false)
       end
 
+      it 'returns false when attempting a vertical move to a space containing an opponent piece' do
+        create(:knight, x_coordinate: 0, y_coordinate: 2, game_id: @game.id, color: 'Black')
+        expect(@pawn.valid_move?(0, 2)).to eq(false)
+      end
+
       it 'returns false for a move 1 right, 0 forward' do
         expect(@pawn.valid_move?(1, 1)).to eq(false)
       end
@@ -52,8 +57,8 @@ RSpec.describe Pawn, type: :model do
       end
 
       it 'returns true for a 1 forward, diagonal move to an opponent space' do
-        create(:knight, x_coordinate: 1, y_coordinate: 2, color: 'Black')
-        expect(@pawn.valid_move?(1, 2))
+        create(:knight, x_coordinate: 1, y_coordinate: 2, color: 'Black', game_id: @game.id)
+        expect(@pawn.valid_move?(1, 2)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
I fixed the bug in the Pawn model that was allowing vertical attacks on opponents and not allowing diagonal attacks as intended. I did not change the first_move? method to use the moved column in the database in this pull request. Time permitting, after completing my next task, I will add it as a new task ticket.
