### PR TITLE
Br/en passant

### DIFF
--- a/app/models/en_passant.rb
+++ b/app/models/en_passant.rb
@@ -1,0 +1,7 @@
+class EnPassant < ActiveRecord::Base
+  belongs_to :pawn
+
+  def self.find_by_coordinates(x, y)
+    where(x_coordinate: x, y_coordinate: y).first
+  end
+end

--- a/app/models/en_passant.rb
+++ b/app/models/en_passant.rb
@@ -2,6 +2,8 @@ class EnPassant < ActiveRecord::Base
   belongs_to :piece
   belongs_to :game
 
+  scope :color, ->(given_color) { where(color: given_color) }
+
   def self.find_by_coordinates(x, y)
     where(x_coordinate: x, y_coordinate: y).first
   end

--- a/app/models/en_passant.rb
+++ b/app/models/en_passant.rb
@@ -1,7 +1,11 @@
 class EnPassant < ActiveRecord::Base
-  belongs_to :pawn
+  belongs_to :piece
+  belongs_to :game
 
   def self.find_by_coordinates(x, y)
     where(x_coordinate: x, y_coordinate: y).first
+  end
+
+  def capture
   end
 end

--- a/app/models/en_passant.rb
+++ b/app/models/en_passant.rb
@@ -7,5 +7,6 @@ class EnPassant < ActiveRecord::Base
   end
 
   def capture
+    piece.destroy if piece.type = 'Pawn'
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,7 +3,7 @@ class Game < ActiveRecord::Base
   belongs_to :black_player, class_name: 'Player'
   belongs_to :white_player, class_name: 'Player'
   has_many :pieces
-  has_many :en_passants, through: :pawns
+  has_many :en_passants
 
   after_create :populate_board!
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,6 +3,7 @@ class Game < ActiveRecord::Base
   belongs_to :black_player, class_name: 'Player'
   belongs_to :white_player, class_name: 'Player'
   has_many :pieces
+  has_many :en_passants, through: :pawns
 
   after_create :populate_board!
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -17,6 +17,7 @@ class Pawn < Piece
     move_y = move_y(y_new).abs
     move_x = move_x(x_new)
     create_en_passant if two_spaces_forward?(move_x, move_y)
+    attack_any_en_passant(x_new, y_new)
     super
   end
 
@@ -65,9 +66,14 @@ class Pawn < Piece
 
   def create_en_passant
     y = color == 'White' ? 2 : 5
-    e = en_passants.create(x_coordinate: x_coordinate,
+    en_passants.create(x_coordinate: x_coordinate,
                        y_coordinate: y,
                        color: color,
                        game_id: game.id)
+  end
+
+  def attack_any_en_passant(x, y)
+    en_passant = game.en_passants.find_by_coordinates(x, y)
+    en_passant && en_passant.capture
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,16 +1,25 @@
 # Class for Pawn Piece
 class Pawn < Piece
+  has_many :en_passants, dependent: :destroy
+
   def valid_move?(x_new, y_new)
     return false if is_obstructed?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
     return false unless forward_move?(y_new)
     move_y = move_y(y_new)
     move_x = move_x(x_new)
-    return false unless (first_move? && move_y.abs <= 2) || move_y.abs <= 1
-    if space_occupied?(x_new, y_new) || move_x != 0
-      return false unless attack?(x_new, y_new)
-    end
-    true
+    occupied ||= space_occupied?(x_new, y_new)
+
+    (one_space_forward?(move_x, move_y.abs) && !occupied) ||
+      (two_spaces_forward?(move_x, move_y.abs) && !occupied) ||
+      (diagonal?(move_x, move_y) && attack?(x_new, y_new))
+  end
+
+  def move(x_new, y_new)
+    move_y = move_y(y_new).abs
+    move_x = move_x(x_new)
+    create_en_passant if two_spaces_forward?(move_x, move_y)
+    super
   end
 
   def forward_move?(y_new)
@@ -18,6 +27,14 @@ class Pawn < Piece
     return false if color == 'White' && move_y <= 0
     return false if color == 'Black' && move_y >= 0
     true
+  end
+
+  def one_space_forward?(move_x, move_y)
+    move_x == 0 && move_y == 1
+  end
+
+  def two_spaces_forward?(move_x, move_y)
+    move_x == 0 && move_y == 2 && first_move?
   end
 
   def move_y(y_new)
@@ -37,12 +54,21 @@ class Pawn < Piece
     game.pieces.find_by_coordinates(x_new, y_new)
   end
 
+  def diagonal?(move_x, move_y)
+    move_x == 1 && move_y == 1
+  end
+
   def attack?(x_new, y_new)
-    move_x = move_x(x_new)
-    move_y = move_y(y_new).abs
-    return false unless move_x == 1 && move_y == 1
-    return false unless space_occupied?(x_new, y_new)
-    return false if move_attacking_own_piece?(x_new, y_new, color)
-    true
+    object = game.pieces.find_by_coordinates(x_new, y_new) ||
+             game.en_passants.find_by_coordinates(x_new, y_new)
+    return false unless object
+    opposite_color == object.color
+  end
+
+  def create_en_passant
+    y = color == 'White' ? 2 : 5
+    en_passants.create(x_coordinate: x_coordinate,
+                       y_coordinate: y,
+                       color: color)
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -8,9 +8,9 @@ class Pawn < Piece
     move_x = move_x(x_new)
     occupied ||= space_occupied?(x_new, y_new)
 
-    (one_space_forward?(move_x, move_y.abs) && !occupied) ||
+    return (one_space_forward?(move_x, move_y.abs) && !occupied) ||
       (two_spaces_forward?(move_x, move_y.abs) && !occupied) ||
-      (diagonal?(move_x, move_y) && attack?(x_new, y_new))
+      (diagonal?(move_x, move_y.abs) && attack?(x_new, y_new))
   end
 
   def move(x_new, y_new)
@@ -19,6 +19,7 @@ class Pawn < Piece
     move_x = move_x(x_new)
     create_en_passant if two_spaces_forward?(move_x, move_y)
     attack_any_en_passant(x_new, y_new)
+    find_and_capture(x_new, y_new)
     update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
     destroy_en_passants
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,7 +1,5 @@
 # Class for Pawn Piece
 class Pawn < Piece
-  has_many :en_passants, dependent: :destroy
-
   def valid_move?(x_new, y_new)
     return false if is_obstructed?(x_new, y_new)
     return false if move_attacking_own_piece?(x_new, y_new, color)
@@ -67,8 +65,9 @@ class Pawn < Piece
 
   def create_en_passant
     y = color == 'White' ? 2 : 5
-    en_passants.create(x_coordinate: x_coordinate,
+    e = en_passants.create(x_coordinate: x_coordinate,
                        y_coordinate: y,
-                       color: color)
+                       color: color,
+                       game_id: game.id)
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -14,11 +14,13 @@ class Pawn < Piece
   end
 
   def move(x_new, y_new)
+    return false unless valid_move?(x_new, y_new)
     move_y = move_y(y_new).abs
     move_x = move_x(x_new)
     create_en_passant if two_spaces_forward?(move_x, move_y)
     attack_any_en_passant(x_new, y_new)
-    super
+    update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
+    destroy_en_passants
   end
 
   def forward_move?(y_new)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -38,6 +38,9 @@ class Piece < ActiveRecord::Base
       # This next line checks that a captured piece exists and destroys it.
       captured_piece && captured_piece.destroy
       update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
+      # destroy all enpassants on the other side to prevent them from being
+      # valid moves in subsequent turns
+      game.en_passants.color(opposite_color).destroy_all
       return true if save
     end
     false
@@ -49,7 +52,7 @@ class Piece < ActiveRecord::Base
     elsif color == 'Black'
       'White'
     else
-      raise 'Invalid color given'
+      raise 'not a valid color'
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,6 +1,7 @@
 class Piece < ActiveRecord::Base
   belongs_to :player
   belongs_to :game
+  has_many :en_passants, dependent: :destroy
   scope :bishops, -> { where(type: 'Bishop') }
   scope :kings, -> { where(type: 'King') }
   scope :knights, -> { where(type: 'Knight') }

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -34,16 +34,20 @@ class Piece < ActiveRecord::Base
   def move(x_new, y_new)
     return castle!(x_new, y_new) if castling_move?(x_new, y_new)
     if valid_move?(x_new, y_new)
-      captured_piece = game.pieces.find_by_coordinates(x_new, y_new)
-      # This next line checks that a captured piece exists and destroys it.
-      captured_piece && captured_piece.destroy
+      find_and_capture(x_new, y_new)
       update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
       # destroy all enpassants on the other side to prevent them from being
       # valid moves in subsequent turns
-      game.en_passants.color(opposite_color).destroy_all
+      destroy_en_passants
       return true if save
     end
     false
+  end
+
+  def find_and_capture(x, y)
+    captured_piece = game.pieces.find_by_coordinates(x, y)
+    # This next line checks that a captured piece exists and destroys it.
+    captured_piece && captured_piece.destroy
   end
 
   def opposite_color
@@ -102,6 +106,10 @@ class Piece < ActiveRecord::Base
 
   def actual_move?(x_move, y_move)
     x_move != x_coordinate && y_move != y_coordinate
+  end
+
+  def destroy_en_passants
+    game.en_passants.color(opposite_color).destroy_all
   end
 
   private

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,12 +1,12 @@
 class Piece < ActiveRecord::Base
   belongs_to :player
   belongs_to :game
-  scope :bishops, -> { where(type: ‘Bishop’) }
-  scope :kings, -> { where(type: ‘King’) }
-  scope :knights, -> { where(type: ‘Knight’) }
-  scope :pawns, -> { where(type: ‘Pawn’) }
-  scope :queens, -> { where(type: ‘Queen’) }
-  scope :rooks, -> { where(type: ‘Rook’) }
+  scope :bishops, -> { where(type: 'Bishop') }
+  scope :kings, -> { where(type: 'King') }
+  scope :knights, -> { where(type: 'Knight') }
+  scope :pawns, -> { where(type: 'Pawn') }
+  scope :queens, -> { where(type: 'Queen') }
+  scope :rooks, -> { where(type: 'Rook') }
   # Adding scope allow calling methods like, Piece.kings, Piece.pawns, Piece.rooks
   # Piece.all, King.all, Pawn.all, Rook.all
   # Note sure if this is necessary but will leave it here for now.
@@ -40,6 +40,16 @@ class Piece < ActiveRecord::Base
       return true if save
     end
     false
+  end
+
+  def opposite_color
+    if color == 'White'
+      'Black'
+    elsif color == 'Black'
+      'White'
+    else
+      raise 'Invalid color given'
+    end
   end
 
   def valid_move?(x_new, y_new)

--- a/db/migrate/20160311021515_create_en_passants.rb
+++ b/db/migrate/20160311021515_create_en_passants.rb
@@ -1,0 +1,11 @@
+class CreateEnPassants < ActiveRecord::Migration
+  def change
+    create_table :en_passants do |t|
+      t.integer :x_coordinate
+      t.integer :y_coordinate
+      t.string :color
+      t.integer :pawn_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160311021515_create_en_passants.rb
+++ b/db/migrate/20160311021515_create_en_passants.rb
@@ -4,7 +4,7 @@ class CreateEnPassants < ActiveRecord::Migration
       t.integer :x_coordinate
       t.integer :y_coordinate
       t.string :color
-      t.integer :pawn_id
+      t.integer :piece_id
       t.timestamps
     end
   end

--- a/db/migrate/20160311040620_add_game_id_to_en_passants.rb
+++ b/db/migrate/20160311040620_add_game_id_to_en_passants.rb
@@ -1,0 +1,5 @@
+class AddGameIdToEnPassants < ActiveRecord::Migration
+  def change
+    add_column :en_passants, :game_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160305015502) do
+ActiveRecord::Schema.define(version: 20160311021515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "en_passants", force: true do |t|
+    t.integer  "x_coordinate"
+    t.integer  "y_coordinate"
+    t.string   "color"
+    t.integer  "pawn_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "games", force: true do |t|
     t.integer  "black_player_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311021515) do
+ActiveRecord::Schema.define(version: 20160311040620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,9 +20,10 @@ ActiveRecord::Schema.define(version: 20160311021515) do
     t.integer  "x_coordinate"
     t.integer  "y_coordinate"
     t.string   "color"
-    t.integer  "pawn_id"
+    t.integer  "piece_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "game_id"
   end
 
   create_table "games", force: true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
   factory :piece do
     player
     game_id { FactoryGirl.create(:game).id }
-    color 'white'
+    color 'White'
     x_coordinate 2
     y_coordinate 2
     moved false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,8 @@
 FactoryGirl.define do
+
+  factory :en_passant do
+  end
+
   factory :game do
     black_player
     white_player

--- a/spec/models/en_passant_spec.rb
+++ b/spec/models/en_passant_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe EnPassant, type: :model do
+end

--- a/spec/models/en_passant_spec.rb
+++ b/spec/models/en_passant_spec.rb
@@ -1,4 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe EnPassant, type: :model do
+  describe "when an en passant is captured" do
+    before(:each) do
+      @game = create(:game)
+      @black_pawn = @game.pawns.find_by_coordinates(2, 6)
+      @white_pawn = @game.pawns.find_by_coordinates(3, 1)
+    end
+    it 'destroys the associated pawn' do
+      @white_pawn.update_attributes(y_coordinate: 4, moved: true)
+      @black_pawn.move(2, 4)
+      @white_pawn.move(2, 5)
+      expect(Piece.find_by_id(@black_pawn.id)).to be nil
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe Pawn, type: :model do
       end
     end
   end
+
+  describe 'when a double forward move is made' do
+    before(:each) do
+      @game = create(:game)
+      @pawn = @game.pawns.find_by_coordinates(2, 1)
+    end
+    it 'creates an en passant in the square behind the pawn' do
+      @pawn.move(2, 3)
+      expect(@pawn.en_passants.where(x_coordinate: 2, y_coordinate: 2).first)
+        .not_to be nil
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe Pawn, type: :model do
         create(:knight, x_coordinate: 1, y_coordinate: 2, color: 'Black', game_id: @game.id)
         expect(@pawn.valid_move?(1, 2)).to eq(true)
       end
+
+      it 'returns true when capturing an en passant' do
+        black_pawn = create(:pawn, color: 'Black',
+                                   x_coordinate: 1,
+                                   y_coordinate: 6,
+                                   game_id: @game.id)
+        @pawn.update_attributes(y_coordinate: 4, moved: true)
+        black_pawn.move(1, 4)
+        expect(@pawn.valid_move?(1, 5)).to be true
+      end
     end
   end
 

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Pawn, type: :model do
                                    x_coordinate: 1,
                                    y_coordinate: 6,
                                    game_id: @game.id)
+
         @pawn.update_attributes(y_coordinate: 4, moved: true)
         black_pawn.move(1, 4)
         expect(@pawn.valid_move?(1, 5)).to be true

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -90,4 +90,25 @@ RSpec.describe Pawn, type: :model do
         .not_to be nil
     end
   end
+
+  describe 'when capturing' do
+    before(:each) do
+      @game = create(:game)
+      @black_pawn = @game.pieces.find_by_coordinates(3, 6)
+      @white_pawn = @game.pieces.find_by_coordinates(4, 1)
+      @white_pawn.move(4, 3)
+      @black_pawn.move(3, 4)
+    end
+    it 'moves the piece to the place where the capture occurs' do
+      @black_pawn.move(4, 3)
+      @black_pawn.reload
+      expect(@game.pieces.find_by_coordinates(4, 3).id).to eq @black_pawn.id
+    end
+
+    it 'destroys the captured piece' do
+      white_pawn_id = @white_pawn.id
+      @black_pawn.move(4, 3)
+      expect(Piece.find_by_id(white_pawn_id)).to be nil
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe Piece, type: :model do
       expect(@king.x_coordinate).to eq 5
       expect(@rook.x_coordinate).to eq 4
     end
+
+    it 'destroys all en passants of the opposite color so that en passants are \
+        only valid for one turn' do
+      @game = create(:game)
+      @white_pawn = @game.pieces.find_by_coordinates(3, 1)
+      @black_knight = @game.pieces.find_by_coordinates(1, 7)
+      @white_pawn.move(3, 3)
+      @black_knight.move(2, 5)
+      expect(@game.en_passants).to be_empty
+    end
   end
 
 


### PR DESCRIPTION
The en passant move is now enabled. I had to create a Model called EnPassants. An en_passant object has x and y coordinates, a color, and belongs to a piece(should be a pawn), and a game. An en_passant object is created when a pawn moves two spaces forward, it's coordinates are the square behind the pawn that creates it, it's color is the same as it's associated pawn.

Other pawns are able to capture the en passant which causes it's associated pawn to be captured.

En passants are destroyed when a piece of the opposite color moves to keep them from being valid for more than one turn.
