### PR TITLE
Br/check

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -52,7 +52,8 @@ class Game < ActiveRecord::Base
     pieces.create(:type => 'Rook', :color => "White", :x_coordinate => 7, :y_coordinate => 0)
   end
 
-  def check?(king)
+  def check?(color)
+    king = kings.find_by! color: color
     opponents = pieces.where(color: king.opposite_color)
     opponents.any? do |piece|
       piece.valid_move?(king.x_coordinate, king.y_coordinate)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -22,11 +22,15 @@ class King < Piece
     return false if rook.moved
     # return false if a piece is in the way
     return false if is_obstructed?(rook_x, rook_y)
-    # One of the rules for castling requires that the king not be in check, and
-    # all the squares that the king will move through during the castle are not
-    # in check. Will need to add code for that when check testing has been
-    # implemented.
+    # Check that none of the spaces that the king moves through are attacked
+    spaces_moved_through_by_castle(rook_x).each do |x_space|
+      return false if move_into_check?(x_space, y_coordinate)
+    end
     true
+  end
+
+  def spaces_moved_through_by_castle(rook_x)
+    rook_x == 7 ? [4, 5] : [1, 2]
   end
 
   def castle!(rook_x, rook_y)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -2,7 +2,6 @@ class King < Piece
   def valid_move?(new_x, new_y)
     guard_move_is_on_board?(new_x, new_y)
     return false unless one_space?(new_x, new_y)
-    return false if move_into_check?(new_x, new_y)
     piece = game.pieces.find_by_coordinates(new_x, new_y)
     return false unless piece.nil? || piece.color != color
     true
@@ -43,11 +42,5 @@ class King < Piece
     # Move the rook.
     rook.update_attributes(x_coordinate: rook_move, moved: true)
     return true if rook.save && save
-  end
-
-  def move_into_check?(x_new, y_new)
-    self.x_coordinate = x_new
-    self.y_coordinate = y_new
-    game.check?(self)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -33,7 +33,7 @@ class Piece < ActiveRecord::Base
 
   def move(x_new, y_new)
     return castle!(x_new, y_new) if castling_move?(x_new, y_new)
-    if valid_move?(x_new, y_new)
+    if valid_move?(x_new, y_new) && !move_into_check?(x_new, y_new)
       find_and_capture(x_new, y_new)
       update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
       # destroy all enpassants on the other side to prevent them from being

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe Game, type: :model do
     context 'Pawn' do
       it 'should return true if the opponent Pawn can capture the King' do
         @pawn = create(:pawn, game_id: @game.id, x_coordinate: 3, y_coordinate: 1, color: 'Black')
-        expect(@game.check?(@king)).to eq true
+        expect(@game.check?(@king.color)).to eq true
       end
     end
 
     context 'Knight' do
       it 'should return true if the opponent Knight can capture the King' do
         @knight = create(:knight, game_id: @game.id, x_coordinate: 3, y_coordinate: 2, color: 'Black')
-        expect(@game.check?(@king)).to eq true
+        expect(@game.check?(@king.color)).to eq true
       end
     end
 
@@ -45,12 +45,12 @@ RSpec.describe Game, type: :model do
       end
 
       it 'should return true if the opponent Rook can capture the King' do
-        expect(@game.check?(@king)).to eq true
+        expect(@game.check?(@king.color)).to eq true
       end
 
       it 'should return false if the Rook is blocked by another piece' do
         @pawn = create(:pawn, game_id: @game.id, x_coordinate: 4, y_coordinate: 1, color: 'White')
-        expect(@game.check?(@king)).to eq false
+        expect(@game.check?(@king.color)).to eq false
       end
     end
 
@@ -60,28 +60,28 @@ RSpec.describe Game, type: :model do
       end
 
       it 'should return true if the opponent Bishop can capture the King' do
-        expect(@game.check?(@king)).to eq true
+        expect(@game.check?(@king.color)).to eq true
       end
 
       it 'should return false if the Bishop is blocked by another piece' do
         @pawn = create(:pawn, game_id: @game.id, x_coordinate: 3, y_coordinate: 1, color: 'White')
-        expect(@game.check?(@king)).to eq false
+        expect(@game.check?(@king.color)).to eq false
       end
     end
 
-    # NOTE: Please uncomment the test below and remove this line when valid_move? for the Queen is complete
-    # context 'Queen' do
-    #   before(:each) do
-    #     @queen = create(:queen, game_id: @game.id, x_coordinate: 2, y_coordinate: 2, color: 'Black')
-    #   end
+    context 'Queen' do
+      before(:each) do
+        @queen = create(:queen, game_id: @game.id, x_coordinate: 2, y_coordinate: 2, color: 'Black')
+      end
 
-    #   it 'should return true if the opponent Queen can capture the King' do
-    #     expect(@game.check?(@king, @queen)).to eq true
-    #   end
+      it 'should return true if the opponent Queen can capture the King' do
+        expect(@game.check?(@king.color)).to eq true
+      end
 
-    #   it 'should return false if the Queen is blocked by another piece' do
-    #     @pawn = create(:pawn, game_id: @game.id, x_coordinate: 3, y_coordinate: 1, color: 'White')
-    #   end
-    # end
+      it 'should return false if the Queen is blocked by another piece' do
+        @pawn = create(:pawn, game_id: @game.id, x_coordinate: 3, y_coordinate: 1, color: 'White')
+        expect(@game.check?(@king.color)).to eq false
+      end
+    end
   end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -100,6 +100,36 @@ RSpec.describe King, type: :model do
         expect(@king.can_castle?(7, 0)).to be false
       end
     end
+
+    context 'when one of the squares between the king and rook is attacked' do
+      before(:each) do
+        @black_queen = create(:queen, color: 'Black', x_coordinate: 4,
+                                      y_coordinate: 7, game_id: @game.id)
+      end
+      it 'should return false if the king moves through an attacked space on queen_side' do
+        expect(@king.can_castle?(7, 0)).to be false
+      end
+
+      it 'should return false if the king moves through an attacked space on king_side' do
+        @black_queen.update_attributes(x_coordinate: 2)
+        expect(@king.can_castle?(0, 0)).to be false
+      end
+
+      it 'should return false if the king lands attacked space on queen_side' do
+        @black_queen.update_attributes(x_coordinate: 5)
+        expect(@king.can_castle?(7, 0)).to be false
+      end
+
+      it 'should return false if the king lands attacked space on king_side' do
+        @black_queen.update_attributes(x_coordinate: 1)
+        expect(@king.can_castle?(0, 0)).to be false
+      end
+
+      it 'should return true if only the rook moves through an attacked space' do
+        @black_queen.update_attributes(x_coordinate: 6)
+        expect(@king.can_castle?(7, 0)).to be true
+      end
+    end
   end
 
   describe '#castle!' do

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -129,26 +129,4 @@ RSpec.describe King, type: :model do
       expect(@queen_side_rook.x_coordinate).to eq 4
     end
   end
-
-  describe 'move_into_check?' do
-    before(:each) do
-      @game = create(:game)
-      @king = @game.pieces.find_by_coordinates(3, 0)
-      # This destroys the pawns in front of the Kings and Queens
-      @game.pieces.where(x_coordinate: [3, 4], y_coordinate: [1, 6]).destroy_all
-      # I was thinking I would just let the queen do the checking but then I
-      # the queen still hasn't had it's valid_move pushed.
-      # We can delete the next line and this comment when it is.
-      @rook = create(:rook, game_id: @game.id, x_coordinate: 4, y_coordinate: 6, color: 'Black')
-    end
-
-    it 'should return true if a move by the King would put it in check' do
-      expect(@king.move_into_check?(4, 0)).to eq true
-    end
-
-    it 'should return false if a move by the King would not put it in check' do
-      @pawn = create(:pawn, game_id: @game.id, x_coordinate: 4, y_coordinate: 5, color: 'Black')
-      expect(@king.move_into_check?(4, 0)).to eq false
-    end
-  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -112,4 +112,40 @@ RSpec.describe Piece, type: :model do
       expect(Piece.find_by_id(pawn_id)).to be_nil
     end
   end
+
+  describe '#move_into_check?' do
+    before(:each) do
+      @game = create(:game)
+      @game.pawns.find_by_coordinates(3, 1).move(3, 3)
+      @game.pawns.find_by_coordinates(4, 6).move(4, 4)
+      @white_queen = @game.queens.find_by!(color: 'White')
+      @black_king = @game.kings.find_by!(color: 'Black')
+      @white_king = @game.kings.find_by!(color: 'White')
+    end
+
+    it 'returns true when moving the king into check' do
+      @white_queen.move(1, 3)
+      expect(@black_king.move_into_check?(4, 6)).to be true
+      black_bishop = @game.bishops.find_by_coordinates(5, 7)
+      black_bishop.move(1, 3)
+      expect(@white_king.move_into_check?(3, 1)).to be true
+      expect(@white_king.move_into_check?(4, 0)).to be true
+    end
+
+    it 'returns false when a king is moving out of check' do
+
+    end
+
+    it 'returns true when moving a non-king piece would put your king in check' do
+
+    end
+
+    it 'returns false when capturing a piece that had your king in check' do
+
+    end
+
+    it 'returns true when performing an en passant would put your king in check' do
+
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Piece, type: :model do
       @game = create(:game)
       @game.pieces.destroy_all
       @bishop = create(:bishop, game_id: @game.id)
+      create(:king, game_id: @game.id, y_coordinate: 0)
     end
     it 'moves the piece to the correct place when move is valid' do
       @bishop.move(5, 5)
@@ -64,6 +65,13 @@ RSpec.describe Piece, type: :model do
     end
     it 'does not move piece on an invalid move' do
       @bishop.move(4, 5)
+      @bishop.reload
+      expect(@bishop.x_coordinate).to eq 2
+      expect(@bishop.y_coordinate).to eq 2
+    end
+    it 'does not move if the move would put your king in check' do
+      create(:queen, y_coordinate: 7, color: 'Black', game_id: @game.id)
+      @bishop.move(5, 5)
       @bishop.reload
       expect(@bishop.x_coordinate).to eq 2
       expect(@bishop.y_coordinate).to eq 2
@@ -103,6 +111,7 @@ RSpec.describe Piece, type: :model do
       @game = create(:game)
       @game.pieces.destroy_all
       @bishop = create(:bishop, game_id: @game.id)
+      create(:king, game_id: @game.id, y_coordinate: 0)
       @pawn = create(:pawn, color: 'Black', game_id: @game.id, x_coordinate: 5, y_coordinate: 5)
     end
     it 'removes the captured piece' do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -116,36 +116,45 @@ RSpec.describe Piece, type: :model do
   describe '#move_into_check?' do
     before(:each) do
       @game = create(:game)
-      @game.pawns.find_by_coordinates(3, 1).move(3, 3)
-      @game.pawns.find_by_coordinates(4, 6).move(4, 4)
-      @white_queen = @game.queens.find_by!(color: 'White')
-      @black_king = @game.kings.find_by!(color: 'Black')
-      @white_king = @game.kings.find_by!(color: 'White')
+      @game.pieces.destroy_all
+      @white_king = create(:king, x_coordinate: 3, y_coordinate: 0, game_id: @game.id)
+      @white_queen = create(:queen, x_coordinate: 4, y_coordinate: 0, game_id: @game.id)
+      @black_king = create(:king, x_coordinate: 3, y_coordinate: 7, color: 'Black', game_id: @game.id)
+      @black_queen = create(:queen, x_coordinate: 4, y_coordinate: 7, color: 'Black', game_id: @game.id)
     end
 
     it 'returns true when moving the king into check' do
-      @white_queen.move(1, 3)
-      expect(@black_king.move_into_check?(4, 6)).to be true
-      black_bishop = @game.bishops.find_by_coordinates(5, 7)
-      black_bishop.move(1, 3)
-      expect(@white_king.move_into_check?(3, 1)).to be true
-      expect(@white_king.move_into_check?(4, 0)).to be true
+      expect(@white_king.move_into_check?(4,1)).to be true
+      expect(@black_king.move_into_check?(4,6)).to be true
     end
 
     it 'returns false when a king is moving out of check' do
-
+      @black_queen.move(3, 6)
+      expect(@white_king.move_into_check?(2,0)).to be false
     end
 
     it 'returns true when moving a non-king piece would put your king in check' do
-
+      @white_queen.move(3, 1)
+      @black_queen.move(3, 6)
+      expect(@white_queen.move_into_check?(4,1)).to be true
     end
 
     it 'returns false when capturing a piece that had your king in check' do
-
+      @white_queen.move(3, 1)
+      @black_queen.move(3, 6)
+      expect(@white_queen.move_into_check?(3, 6)).to be false
     end
 
     it 'returns true when performing an en passant would put your king in check' do
+      white_pawn = create(:pawn, x_coordinate: 3, y_coordinate: 1, game_id: @game.id)
+      black_pawn = create(:pawn, x_coordinate: 4, y_coordinate: 3, moved: true, color: 'Black', game_id: @game.id)
+      @black_king.update_attributes(x_coordinate: 0, y_coordinate: 0)
+      @black_queen.update_attributes(x_coordinate: 0, y_coordinate: 3)
+      @white_queen.update_attributes(x_coordinate: 5, y_coordinate: 5)
+      @white_king.update_attributes(x_coordinate: 6, y_coordinate: 5)
 
+      white_pawn.move(3, 3)
+      expect(black_pawn.move_into_check?(3, 2)).to be true
     end
   end
 end


### PR DESCRIPTION
Created a move_into_check method on the Piece model.

The method takes any piece that would be captured in the move and places it at coordinates off the board where the piece is incapable of attacking any other pieces on the board.

Then moves the piece to the chosen coordinates and calls the check? method. 

Then it returns all pieces to their original places and returns the results of the check? method.

I realize that moving everything, then putting it back, then finishing the move method is inefficient on the database, however to make the method work with castling, where it needs to be called twice, the castle method may have to be rewritten if we do it the efficient way.

I am calling the move_into_check method from the move method, instead of the valid_move because the check? method calls valid_move? creating the possibility for infinite loops.
