### PR TITLE
Br/check

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -14,7 +14,7 @@ class Pawn < Piece
   end
 
   def move(x_new, y_new)
-    return false unless valid_move?(x_new, y_new)
+    return false unless valid_move?(x_new, y_new) && !move_into_check?(x_new, y_new)
     move_y = move_y(y_new).abs
     move_x = move_x(x_new)
     create_en_passant if two_spaces_forward?(move_x, move_y)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -56,7 +56,7 @@ class Piece < ActiveRecord::Base
     # Update attributes
     update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
     # Determine if this has moved the player into check, save it to variable
-    check = game.check?(color
+    check = game.check?(color)
     # Put everything back
     update_attributes(old_attributes)
     if attacked_piece

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -50,7 +50,7 @@ class Piece < ActiveRecord::Base
     # Determine if move is EnPassant and remove attacked piece from board
     attacked_piece ||= deterimine_en_passant(x_new, y_new)
     attacked_piece && attacked_piece.place_off_board
-
+    puts attacked_piece.inspect
 
     # Remember where the piece came from, so we can put it back.
     old_attributes = { x_coordinate: x_coordinate, y_coordinate: y_coordinate, moved: moved }
@@ -58,6 +58,7 @@ class Piece < ActiveRecord::Base
     update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
     # Determine if this has moved the player into check, save it to variable
     check = game.check?(color)
+    puts check
     # Put everything back
     update_attributes(old_attributes)
     if attacked_piece

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -50,15 +50,13 @@ class Piece < ActiveRecord::Base
     # Determine if move is EnPassant and remove attacked piece from board
     attacked_piece ||= deterimine_en_passant(x_new, y_new)
     attacked_piece && attacked_piece.place_off_board
-    puts attacked_piece.inspect
 
     # Remember where the piece came from, so we can put it back.
     old_attributes = { x_coordinate: x_coordinate, y_coordinate: y_coordinate, moved: moved }
     # Update attributes
     update_attributes(x_coordinate: x_new, y_coordinate: y_new, moved: true)
     # Determine if this has moved the player into check, save it to variable
-    check = game.check?(color)
-    puts check
+    check = game.check?(color
     # Put everything back
     update_attributes(old_attributes)
     if attacked_piece

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Pawn, type: :model do
       @game = create(:game)
       @game.pieces.destroy_all
       @pawn = create(:pawn, game_id: @game.id, x_coordinate: 0, y_coordinate: 1, color: 'White')
+      create(:king, game_id: @game.id, x_coordinate: 3, y_coordinate: 0)
     end
 
     context 'an invalid move' do
@@ -79,6 +80,8 @@ RSpec.describe Pawn, type: :model do
                                    x_coordinate: 1,
                                    y_coordinate: 6,
                                    game_id: @game.id)
+        create(:king, x_coordinate:3, y_coordinate: 7, game_id: @game.id,
+                      color: 'Black')
 
         @pawn.update_attributes(y_coordinate: 4, moved: true)
         black_pawn.move(1, 4)

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Piece, type: :model do
       @game = create(:game)
       @game.pieces.destroy_all
       @bishop = create(:bishop, game_id: @game.id)
-      create(:king, game_id: @game.id, y_coordinate: 0)
+      @king = create(:king, game_id: @game.id, y_coordinate: 0)
     end
     it 'moves the piece to the correct place when move is valid' do
       @bishop.move(5, 5)
@@ -75,6 +75,27 @@ RSpec.describe Piece, type: :model do
       @bishop.reload
       expect(@bishop.x_coordinate).to eq 2
       expect(@bishop.y_coordinate).to eq 2
+    end
+    it 'does not allow when you are in check and the proposed move would not get
+        you out of check' do
+      @king.update_attributes(x_coordinate: 3)
+      create(:knight, x_coordinate: 4, y_coordinate: 2, game_id: @game.id,
+                      color: 'Black')
+      @bishop.move(5, 5)
+      @bishop.reload
+      expect(@bishop.x_coordinate).to eq 2
+      expect(@bishop.y_coordinate).to eq 2
+    end
+
+    it 'does not allow when you are in check and the proposed move would not get
+        you out of check' do
+      @king.update_attributes(x_coordinate: 3)
+      create(:knight, x_coordinate: 4, y_coordinate: 2, game_id: @game.id,
+                      color: 'Black')
+      pawn = create(:pawn, x_coordinate: 0, y_coordinate: 1, game_id: @game.id)
+      pawn.move(0, 2)
+      pawn.reload
+      expect(pawn.y_coordinate).to eq 1
     end
 
     it 'changes the moved attribute to true' do
@@ -164,6 +185,12 @@ RSpec.describe Piece, type: :model do
 
       white_pawn.move(3, 3)
       expect(black_pawn.move_into_check?(3, 2)).to be true
+    end
+
+    it 'returns true when you are in check and the proposed move does not get
+        you out of check' do
+      create(:knight, x_coordinate: 2, y_coordinate: 5, game_id: @game.id)
+      expect(@black_queen.move_into_check?(4, 6)).to be true
     end
   end
 end


### PR DESCRIPTION
I found a bug where pawns could still move in a way that placed their King in check. I wrote a test that isolated that isolated the problem. It turns out that I had forgotten that pawns have their own move method and neglected to call move_into_check in the Pawn#move method. I fixed that, then I fixed some of the Pawn specs that were calling the move method on Pawns and were now raising errors by creating a King for the pawn before running the test.
