### PR TITLE
Br/checkmate

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -67,15 +67,16 @@ class Game < ActiveRecord::Base
   def player_has_valid_moves?(color)
     players_pieces = pieces.where(color: color)
     players_pieces.each do |piece|
-      8.times do |x_space|
-        8.times do |y_space|
-          if piece.valid_move?(x_space, y_space) &&
-             !piece.move_into_check?(x_space, y_space)
-            return true
-          end
-        end
-      end
+      return true if piece.has_valid_moves?
     end
     false
+  end
+
+  def all_board_spaces
+    two_d_array = []
+    8.times do |x|
+      8.times { |y| two_d_array << [x, y] }
+    end
+    two_d_array
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -59,4 +59,23 @@ class Game < ActiveRecord::Base
       piece.valid_move?(king.x_coordinate, king.y_coordinate)
     end
   end
+
+  def player_in_checkmate?(color)
+    check?(color) && !player_has_valid_moves?(color)
+  end
+
+  def player_has_valid_moves?(color)
+    players_pieces = pieces.where(color: color)
+    players_pieces.each do |piece|
+      8.times do |x_space|
+        8.times do |y_space|
+          if piece.valid_move?(x_space, y_space) &&
+             !piece.move_into_check?(x_space, y_space)
+            return true
+          end
+        end
+      end
+    end
+    false
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -146,6 +146,18 @@ class Piece < ActiveRecord::Base
     game.en_passants.color(opposite_color).destroy_all
   end
 
+  def has_valid_moves?
+    game.all_board_spaces.each do |arr|
+      x = arr[0]
+      y = arr[1]
+      if valid_move?(x, y) &&
+         !move_into_check?(x, y)
+        return true
+      end
+    end
+    false
+  end
+
   private
 
   def castling_move?(x_move, y_move)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -15,4 +15,11 @@
   <% end %>
 </table>
 
+<% %w(Black White).each do |color| %>
+  <% if @game.check?(color) %>
+    <% check_or_checkmate = @game.player_in_checkmate?(color) ? 'checkmate' : 'check' %>
+    <%= content_tag :h3, "#{color} Player is in #{check_or_checkmate}" %>
+  <% end %>
+<% end %>
+
 <%= link_to 'Resign', game_path(@game), method: :delete, confirm: 'Are you sure you want to forfeit?', class: 'btn btn-danger' %>

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -84,4 +84,50 @@ RSpec.describe Game, type: :model do
       end
     end
   end
+
+  describe 'player_has_valid_moves' do
+    before(:each) do
+      @game = create(:game)
+      @game.pieces.destroy_all
+      @white_king = create(:king, game_id: @game.id, x_coordinate: 0, y_coordinate: 0)
+      @black_king = create(:king, game_id: @game.id, x_coordinate: 7, y_coordinate: 7, color:'Black')
+    end
+
+    it 'returns false when a player has no valid moves' do
+      create(:rook, game_id: @game.id, x_coordinate: 1, y_coordinate: 6, color: 'Black')
+      create(:rook, game_id: @game.id, x_coordinate: 6, y_coordinate: 1, color: 'Black')
+      expect(@game.player_has_valid_moves?('White')).to be false
+    end
+
+    it 'returns true when a player has valid moves' do
+      create(:rook, game_id: @game.id, x_coordinate: 1, y_coordinate: 6, color: 'Black')
+      expect(@game.player_has_valid_moves?('White')).to be true
+    end
+  end
+
+  describe 'player_in_checkmate' do
+    before(:each) do
+      @game = create(:game)
+      @white_queen = @game.pieces.find_by(type: 'Queen', color: 'White')
+      @white_bishop = @game.pieces.find_by_coordinates(2, 0)
+      @white_queen.update_attributes(x_coordinate: 0, y_coordinate: 4)
+    end
+
+    it 'returns false when the player is not in check' do
+      expect(@game.player_in_checkmate?('Black')).to be false
+    end
+
+    it 'returns false when the player is in check but can get out of check' do
+      black_knight = @game.pieces.find_by_coordinates(1, 7)
+      black_knight.move(0, 5)
+      @white_queen.move(2, 6)
+      expect(@game.player_in_checkmate?('Black')).to be false
+    end
+
+    it 'returns true when the player is in checkmate' do
+      @white_bishop.update_attributes(x_coordinate: 5, y_coordinate: 3)
+      @white_queen.move(2, 6)
+      expect(@game.player_in_checkmate?('Black')).to be true
+    end
+  end
 end


### PR DESCRIPTION
Set up a method that determines when a player is in checkmate.  The only place it is being called right now is in the view, where a message is displayed indicating when a player is in check or checkmate.

I think it's a short jump from here to getting the stalemate working. But I think I will wait for the alternating turns to be set up as a stalemate requires that you have no valid moves and it's your turn.
