### PR TITLE
Addressed deprecation of confirm attribute in link

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,4 +22,4 @@
   <% end %>
 <% end %>
 
-<%= link_to 'Resign', game_path(@game), method: :delete, confirm: 'Are you sure you want to forfeit?', class: 'btn btn-danger' %>
+<%= link_to 'Resign', game_path(@game), method: :delete, data: { confirm: 'Are you sure you want to forfeit?' }, class: 'btn btn-danger' %>


### PR DESCRIPTION
I received a warning that the confirm argument in the link_to helper
method was deprecated. I moved the confirm to a data block.
